### PR TITLE
jq.py のスクリプトを呼び出すときのパスを絶対パスに変更

### DIFF
--- a/script/ufw-update.sh
+++ b/script/ufw-update.sh
@@ -39,7 +39,7 @@ get_address(){
 fastly_address(){
      fastly_json="$tempdir/json"
      curl -f -s -o "$fastly_json" https://api.fastly.com/public-ip-list
-     ./jq.py < "$fastly_json"
+     $(dirname $(realpath "$0"))/jq.py < "$fastly_json"
 }
 
 ufw_diff(){


### PR DESCRIPTION
ufw-update.sh を、このファイルがあるディレクトリ以外で実行すると jq.py が見つからないエラーが発生するので、 jq.py を絶対パスで呼び出すように修正しました。`realpath` はシンボリックリンクでスクリプトを実行した時でも対応できるようにするため使っています。

![image](https://user-images.githubusercontent.com/4638090/100291681-c8439d00-2fc1-11eb-8994-e4d4d4dadd9f.png)
